### PR TITLE
Certificate failure fix

### DIFF
--- a/seeed/1-temperature-sensor/deployment.template.json
+++ b/seeed/1-temperature-sensor/deployment.template.json
@@ -30,7 +30,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0.2", 
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0", 
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             },
             "env": { 

--- a/seeed/1-temperature-sensor/modules/temperature-sensor/hubmanager.py
+++ b/seeed/1-temperature-sensor/modules/temperature-sensor/hubmanager.py
@@ -10,16 +10,30 @@ MESSAGE_TIMEOUT = 10000
 
 class HubManager(object):
 
-    def __init__(self, protocol = IoTHubTransportProvider.MQTT):
+    def __init__(self, connection_string = None, protocol = IoTHubTransportProvider.MQTT):
+        if not connection_string:
+            connection_string = os.environ['EdgeHubConnectionString']
 
         print("\nPython %s\n" % sys.version)
         print("IoT Hub Client for Python")
         print("Starting the IoT Hub Python sample using protocol %s..." % protocol)
 
-        self.client_protocol = protocol
         self.client = IoTHubModuleClient()
         self.client.create_from_environment(protocol)
 
         # set the time until a message times out
         self.client.set_option("messageTimeout", MESSAGE_TIMEOUT)
         # some embedded platforms need certificate information
+        self.set_certificates()
+
+    def set_certificates(self):
+        CERT_FILE = os.environ['EdgeModuleCACertificateFile']
+        print("Adding TrustedCerts from: {0}".format(CERT_FILE))
+
+        # this brings in x509 privateKey and certificate
+        with open(CERT_FILE) as file:
+            try:
+                self.client.set_option("TrustedCerts", file.read())
+                print("set_option TrustedCerts successful")
+            except IoTHubClientError as iothub_client_error:
+                print("set_option TrustedCerts failed (%s)" % iothub_client_error)

--- a/seeed/2-image-classifier/deployment.template.json
+++ b/seeed/2-image-classifier/deployment.template.json
@@ -23,7 +23,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "microsoft/azureiotedge-hub:1.0-preview",
+              "image": "microsoft/azureiotedge-hub:1.0",
               "createOptions": ""
             }
           }

--- a/seeed/3-speech-recognizer/deployment.template.json
+++ b/seeed/3-speech-recognizer/deployment.template.json
@@ -30,7 +30,7 @@
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0.2",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             },
             "env": { 

--- a/seeed/3-speech-recognizer/modules/speech-to-text/hubmanager.py
+++ b/seeed/3-speech-recognizer/modules/speech-to-text/hubmanager.py
@@ -10,16 +10,30 @@ MESSAGE_TIMEOUT = 10000
 
 class HubManager(object):
 
-    def __init__(self, protocol = IoTHubTransportProvider.MQTT):
+    def __init__(self, connection_string = None, protocol = IoTHubTransportProvider.MQTT):
+        if not connection_string:
+            connection_string = os.environ['EdgeHubConnectionString']
 
         print("\nPython %s\n" % sys.version)
         print("IoT Hub Client for Python")
         print("Starting the IoT Hub Python sample using protocol %s..." % protocol)
 
-        self.client_protocol = protocol
         self.client = IoTHubModuleClient()
         self.client.create_from_environment(protocol)
 
         # set the time until a message times out
         self.client.set_option("messageTimeout", MESSAGE_TIMEOUT)
         # some embedded platforms need certificate information
+        self.set_certificates()
+
+    def set_certificates(self):
+        CERT_FILE = os.environ['EdgeModuleCACertificateFile']
+        print("Adding TrustedCerts from: {0}".format(CERT_FILE))
+
+        # this brings in x509 privateKey and certificate
+        with open(CERT_FILE) as file:
+            try:
+                self.client.set_option("TrustedCerts", file.read())
+                print("set_option TrustedCerts successful")
+            except IoTHubClientError as iothub_client_error:
+                print("set_option TrustedCerts failed (%s)" % iothub_client_error)

--- a/seeed/3-speech-recognizer/modules/speech-to-text/main.py
+++ b/seeed/3-speech-recognizer/modules/speech-to-text/main.py
@@ -32,10 +32,10 @@ def mic_callback(text):
 def get_response(text):
     try:
         res = requests.post('http://natural-language-processing:8080/chat', text)
-        if res.content and type(res.content) is str:
-            content = res.content.replace('"', '')
-            print('> {}'.format(content))
-            return content
+        if res.text and type(res.text) is str:
+            response_text = res.text.replace('"', '')
+            print('> {}'.format(response_text))
+            return response_text
     except Exception as e:
         print(e)
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes TLS Handshake/certificate failure issue: https://github.com/Azure-Samples/azure-iot-starter-kits/issues/31
* Fixes bug with _3-speech-recognizer_ tutorial where NLP response is never returned (leading to no commands being recognized)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
    * Prepare Rasberry Pi for tutorial 1/3 (attach relevant modules)
    * Build & Push files for tutorial 1/3
    * Create deployment for single device for tutorial 1/3

## Test the code
<!-- Add steps to run the tests suite and/or manually test -->
* N/A

## What to Check
Verify that the following are valid
* Tutorial 1: Verify that D2C messages can be successfully monitored in VScode
* Tutorial 3:
    * Verify that D2C messages can be successfully monitored in VScode
    * Verify that commands get recognized (e.g. 'time' or 'joke')

## Other Information
Verified that these changes work on my own Raspberry Pi Grove Starter kit. 
I also updated the deployment.template.json for tutorial 2 with EdgeHub tag 1.0, even though I did not experience any issue with this tutorial. 